### PR TITLE
Removed temperature from metric toggle

### DIFF
--- a/offroad/js/components/Settings/Settings.js
+++ b/offroad/js/components/Settings/Settings.js
@@ -303,7 +303,7 @@ class Settings extends Component {
                             title='Use Metric System'
                             value={ !!parseInt(isMetric) }
                             iconSource={ Icons.metric }
-                            description='Display speed in km/h instead of mp/h and temperature in °C instead of °F.'
+                            description='Display speed in km/h instead of mp/h.'
                             isExpanded={ expandedCell == 'metric' }
                             handleExpanded={ () => this.handleExpanded('metric') }
                             handleChanged={ this.props.setMetric } />


### PR DESCRIPTION
openpilot shows temperature in C regardless of this toggle. This description was for the now removed weather information on the off-road screen.