### PR TITLE
calib_description baseui error fix

### DIFF
--- a/offroad/js/components/Settings/Settings.js
+++ b/offroad/js/components/Settings/Settings.js
@@ -452,26 +452,28 @@ class Settings extends Component {
     }
 
     calib_description(params){
-      var text = 'openpilot requires the device to be mounted within 4° left or right and within 5° up or down. openpilot is continuously calibrating, resetting is rarely required.';
-      var calib_json = JSON.parse(params);
-      if (calib_json.hasOwnProperty('calib_radians')) {
-        var calibArr = (calib_json.calib_radians).toString().split(',');
-        var pi = Math.PI;
-        var pitch = parseFloat(calibArr[1]) * (180/pi)
-        var yaw = parseFloat(calibArr[2]) * (180/pi)
-        if (pitch > 0) {
-          var pitch_str = Math.abs(pitch).toFixed(1).concat('° up')
-        } else {
-          var pitch_str = Math.abs(pitch).toFixed(1).concat('° down')
-        }
-        if (yaw > 0) {
-          var yaw_str = Math.abs(yaw).toFixed(1).concat('° right')
-        } else {
+      try {
+        var text = 'openpilot requires the device to be mounted within 4° left or right and within 5° up or down. openpilot is continuously calibrating, resetting is rarely required.';
+        var calib_json = JSON.parse(params);
+        if (calib_json.hasOwnProperty('calib_radians')) {
+          var calibArr = (calib_json.calib_radians).toString().split(',');
+          var pi = Math.PI;
+          var pitch = parseFloat(calibArr[1]) * (180/pi)
+          var yaw = parseFloat(calibArr[2]) * (180/pi)
+          if (pitch > 0) {
+            var pitch_str = Math.abs(pitch).toFixed(1).concat('° up')
+          } else {
+            var pitch_str = Math.abs(pitch).toFixed(1).concat('° down')
+          }
+          if (yaw > 0) {
+            var yaw_str = Math.abs(yaw).toFixed(1).concat('° right')
+          } else {
           var yaw_str = Math.abs(yaw).toFixed(1).concat('° left')
+          }
+          text = text.concat('\n\nYour device is pointed ', pitch_str, ' and ', yaw_str, '. ')
         }
-        text = text.concat('\n\nYour device is pointed ', pitch_str, ' and ', yaw_str, '. ')
-      }
-      return text;
+        return text;
+      } catch (err) { return text.concat('\n\nYour device is reset pointed N/A (up/down) and N/A (left/right).') }
     }
 
     renderDeviceSettings() {


### PR DESCRIPTION
**How to reproduce**
1. Have device EON/C2 and Reset Camera Calibration
2. Going back to Device in Settings will cause a baseui error

**Fix**
I found that the calibration files get removed, so when it tries to parse the json it's probably null. I decided to wrap it in a try{}catch{} and it seemed to fix the problem for me until it's plugged back into the vehicle. There's probably a better way, but thought I should make this to let it be known.