### PR TITLE
Fix dlopen error after put socketmaster.cc in messaging

### DIFF
--- a/library/messaging/src/main/cpp/messaging/lib/arm64-v8a/include/libmessaging/messaging.hpp
+++ b/library/messaging/src/main/cpp/messaging/lib/arm64-v8a/include/libmessaging/messaging.hpp
@@ -23,7 +23,7 @@ public:
 
 class SubSocket {
 public:
-  virtual void connect(Context *context, std::string endpoint, bool conflate=false) = 0;
+  virtual int connect(Context *context, std::string endpoint, std::string address, bool conflate=false) = 0;
   virtual void setTimeout(int timeout) = 0;
   virtual Message *receive(bool non_blocking=false) = 0;
   virtual void * getRawSocket() = 0;
@@ -34,7 +34,7 @@ public:
 
 class PubSocket {
 public:
-  virtual void connect(Context *context, std::string endpoint) = 0;
+  virtual int connect(Context *context, std::string endpoint) = 0;
   virtual int sendMessage(Message *message) = 0;
   virtual int send(char *data, size_t size) = 0;
   static PubSocket * create();


### PR DESCRIPTION
- fix this issue https://github.com/commaai/cereal/pull/50#issuecomment-640194617 .offroad failed to start due to dlopen error:
> logcat -s "messaging"
06-10 18:55:30.119 16609 16635 E messaging: Error opening /data/openpilot/cereal/libmessaging_shared.so ( dlopen failed: library "libcapnp-0.6.1.so" not found )

- messaging.hpp: make sure the class interface same as cereal.

